### PR TITLE
Fix formatting issues

### DIFF
--- a/header.adoc
+++ b/header.adoc
@@ -59,10 +59,7 @@ Copyright 2023 by RISC-V International.
 include::contributors.adoc[]
 
 include::changes.adoc[]
-include::intro.adoc[]
-include::ssdtso.adoc[]
-// include::chapter2.adoc[]
 
-// The index must precede the bibliography
-// include::index.adoc[]
-// include::bibliography.adoc[]
+include::intro.adoc[]
+
+include::ssdtso.adoc[]

--- a/ssdtso.adoc
+++ b/ssdtso.adoc
@@ -23,8 +23,9 @@ The intended use-cases for Ssdtso are
 For its intended use case (i.e., to provide an provide an on-demand RVTSO execution capability for processors otherwise operating in RVWMO), Ssdtso will be used on cores that do not implement Ztso.
 
 However, the Ssdto extension does not conflict with Ztso (i.e., a core that operates in RVTSO mode at all times) and can be implemented on such a core for compatibility:
- * the RVTSO mode is always-on on Ztso implementations, and
- * the DTSO bit in `menvcfg`, `senvcfg` and `henvcfg` will accurately reflect whether the core currently operates in RVTSO mode.
+
+* the RVTSO mode is always-on on Ztso implementations, and
+* the DTSO bit in `menvcfg`, `senvcfg` and `henvcfg` will accurately reflect whether the core currently operates in RVTSO mode.
 
 [NOTE]
 ====
@@ -37,8 +38,9 @@ To allow the free composition of extensions for unforeseen use-cases, no formal 
 
 The dynamic-RVTSO behaviour is controlled by bit 8 (`DTSO`) of `menvcfg`, `senvcfg`, and `henvcfg` for all lower privilege levels.
 Implementations providing Ssdtso initialize the `DTSO`-bit according to their default memory mode:
- * implementations that implement only Ssdtso, and not Ztso, default to use RVWMO semantics natively: the bits controlling dynamic-RVTSO behaviour are initialized to 0 on reset
- * implementations that implement both Ssdtso and Ztso, default to use RVTSO semantics natively: the bits controlling dynamic-RVTSO behaviour are initialized to 1 on reset
+
+* implementations that implement only Ssdtso, and not Ztso, default to use RVWMO semantics natively: the bits controlling dynamic-RVTSO behaviour are initialized to 0 on reset
+* implementations that implement both Ssdtso and Ztso, default to use RVTSO semantics natively: the bits controlling dynamic-RVTSO behaviour are initialized to 1 on reset
 
 If the DTSO control bit in the respective envcfg is set, all lower-privilege modes will operate in dynamic-RVTSO mode:
 [cols="^3,^2,^1,^1,^1,^1,^1",stripes=even,options="header"]


### PR DESCRIPTION
The generated PDF has a few formatting isues, which can be fixed by adjusting whitespace characters a bit (removing spaces and adding newlines). Let's do this, so we have a properly formatted PDF.